### PR TITLE
Wait for ca.key to be loaded before dropping privs

### DIFF
--- a/certs.c
+++ b/certs.c
@@ -513,6 +513,9 @@ void *cert_generator(void *ptr) {
 
     buf[PIXELSERV_MAX_SERVER_NAME * 4] = '\0';
     cert_gen_init(cert_tlstor->pem_dir, &issuer, &key);
+    pthread_mutex_lock(&cert_tlstor->mutex);
+    pthread_cond_signal(&cert_tlstor->cv);
+    pthread_mutex_unlock(&cert_tlstor->mutex);
 
     /* non block required. otherwise blocked until other side opens */
     int fd = open(PIXEL_CERT_PIPE, O_RDONLY | O_NONBLOCK);

--- a/certs.h
+++ b/certs.h
@@ -4,6 +4,7 @@
 #include <arpa/inet.h>
 #include <openssl/pem.h>
 #include <openssl/ssl.h>
+#include <pthread.h>
 
 #define PIXEL_SSL_SESS_CACHE_SIZE 128*20
 #define PIXEL_SSL_SESS_TIMEOUT 3600 /* seconds */
@@ -31,6 +32,8 @@ typedef struct {
     const char* pem_dir;
     X509 *cacert;
     void *stk;
+    pthread_mutex_t mutex;
+    pthread_cond_t cv;
 } cert_tlstor_t;
 
 typedef enum {


### PR DESCRIPTION
When running `pixelserv-tls` with the `-u` argument to drop privileges, there's a race condition that can cause the loading of the private key to fail. The `cert_generator` thread function calls `cert_gen_init`, which can run _after_ `setuid` on the main thread. If this happens, the process may no longer have permission to open the private key file.

This adds a condvar to signal the main thread once the private key has been loaded.
