### PR TITLE
Compile against musl

### DIFF
--- a/certs.c
+++ b/certs.c
@@ -567,7 +567,9 @@ void *cert_generator(void *ptr) {
                     conn_stor_flush();
                     idle = 0;
                 }
+#ifdef __GLIBC__
                 malloc_trim(0);
+#endif
             }
             continue;
         }

--- a/pixelserv.c
+++ b/pixelserv.c
@@ -30,10 +30,6 @@
 #define THREAD_STACK_SIZE  9*PAGE_SIZE
 #define TCP_FASTOPEN_QLEN  25
 
-#ifdef __UCLIBC__
-#define M_ARENA_MAX -1 /* no effect but compile on uClibc */
-#endif
-
 const char *tls_pem = DEFAULT_PEM_PATH;
 int tls_ports[MAX_TLS_PORTS + 1] = {0}; /* one extra port for admin */
 int num_tls_ports = 0;
@@ -130,7 +126,9 @@ int main (int argc, char* argv[])
   int max_num_threads = DEFAULT_THREAD_MAX;
   int cert_cache_size = DEFAULT_CERT_CACHE_SIZE;
 
+#if defined(__GLIBC__)
   mallopt(M_ARENA_MAX, 1);
+#endif
   struct rlimit l = {THREAD_STACK_SIZE, THREAD_STACK_SIZE * 2};
   if (setrlimit(RLIMIT_STACK, &l) == -1)
     log_msg(LGG_ERR, "setrlimit STACK failed: %d %d errno:%d", l.rlim_cur, l.rlim_max, errno);

--- a/pixelserv.c
+++ b/pixelserv.c
@@ -60,7 +60,9 @@ void signal_handler(int sig)
     }
 
     conn_stor_flush();
+#ifdef __GLIBC__
     malloc_trim(0);
+#endif
 
     // log stats
     char* stats_string = get_stats(0, 0);

--- a/pixelserv.c
+++ b/pixelserv.c
@@ -571,7 +571,7 @@ int main (int argc, char* argv[])
       } else {
         // process response type
         switch (pipedata.status) {
-          case FAIL_GENERAL:   ++err; break;
+          case FAIL_GENERAL:   ++ers; break;
           case FAIL_TIMEOUT:   ++tmo; break;
           case FAIL_CLOSED:    ++cls; break;
           case FAIL_REPLY:     ++cly; break;

--- a/pixelserv.c
+++ b/pixelserv.c
@@ -330,11 +330,13 @@ int main (int argc, char* argv[])
   }
 
   mkfifo(PIXEL_CERT_PIPE, 0600);
+#ifdef DROP_ROOT
   pw = getpwnam(user);
   if (chown(PIXEL_CERT_PIPE, pw->pw_uid, pw->pw_gid) < 0) {
       log_msg(LGG_CRIT, "chown failed to set owner of %s to %s", PIXEL_CERT_PIPE, user);
       exit(EXIT_FAILURE);
   }
+#endif
 
   SSL_library_init();
   ssl_init_locks();

--- a/socket_handler.c
+++ b/socket_handler.c
@@ -3,7 +3,7 @@
 #include <ctype.h>
 #include <fcntl.h>
 #include <pthread.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/stat.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>

--- a/util.c
+++ b/util.c
@@ -13,7 +13,7 @@ volatile sig_atomic_t avg = 0;
 volatile sig_atomic_t rmx = 0;
 volatile sig_atomic_t tav = 0;
 volatile sig_atomic_t tmx = 0;
-volatile sig_atomic_t err = 0;
+volatile sig_atomic_t ers = 0;
 volatile sig_atomic_t tmo = 0;
 volatile sig_atomic_t cls = 0;
 volatile sig_atomic_t nou = 0;
@@ -141,7 +141,7 @@ char* get_stats(const int sta_offset, const int stt_offset) {
 
     if (asprintf(&uptimeStr, "%dd %02d:%02d", (int)uptime/86400, (int)(uptime%86400)/3600, (int)((uptime%86400)%3600)/60) < 1
         || asprintf(&retbuf, (sta_offset) ? sta_fmt : stt_fmt,
-        (sta_offset) ? (long)uptimeStr : (long)uptime, log_get_verb(), kcc, kmx, kvg, krq, count, avg, rmx, tav, tmx, slh, slm, sle, slc, slu, uca, uce, sct, sch, scm, scp, sst, ssh, ssm, ssp, nfe, gif, ico, txt, jpg, png, swf, sta + sta_offset, stt + stt_offset, ufe, opt, pst, hed, rdr, nou, pth, noc, bad, tmo, cls, cly, clt, err
+        (sta_offset) ? (long)uptimeStr : (long)uptime, log_get_verb(), kcc, kmx, kvg, krq, count, avg, rmx, tav, tmx, slh, slm, sle, slc, slu, uca, uce, sct, sch, scm, scp, sst, ssh, ssm, ssp, nfe, gif, ico, txt, jpg, png, swf, sta + sta_offset, stt + stt_offset, ufe, opt, pst, hed, rdr, nou, pth, noc, bad, tmo, cls, cly, clt, ers
         ) < 1)
         retbuf = " <asprintf error>";
 

--- a/util.h
+++ b/util.h
@@ -76,7 +76,7 @@ extern volatile sig_atomic_t rmx; // maximum encountered request size
 extern volatile sig_atomic_t _tct; // time count
 extern volatile sig_atomic_t tav; // cumulative moving average time in msec
 extern volatile sig_atomic_t tmx; // max time in msec
-extern volatile sig_atomic_t err;
+extern volatile sig_atomic_t ers;
 extern volatile sig_atomic_t tmo;
 extern volatile sig_atomic_t cls;
 extern volatile sig_atomic_t nou;


### PR DESCRIPTION
Just started playing around with this and had some fun getting things to compile on apline linux (using musl).

Not really a C-coder so probably don't know what I'm doing. But if you have the time I would appreciate some feedback on these changes. Mostly aiming towards two goals, make visual studio code not show warnings, and make the following docker build complete successfully.

```Dockerfile
FROM alpine:latest as builder

RUN apk add --no-cache autoconf automake build-base libressl-dev linux-headers

COPY pixelserv-tls/ /usr/src/pixelserv-tls

ENV CFLAGS -Wextra -flto

WORKDIR /usr/src/pixelserv-tls
RUN set -ex; autoreconf -i; ./configure; make
```

(the err thing was due to a linker warning about it being redefined, I don't expect this to be merged as is as the comment states, a struct is probably a better approach)