### PR TITLE
Fix compilation warnings with gcc-9/clang-9

### DIFF
--- a/certs.c
+++ b/certs.c
@@ -896,7 +896,7 @@ int is_ssl_conn(int fd, char *srv_ip, int srv_ip_len, const int *ssl_ports, int 
 #ifdef TLS1_3_VERSION
 char* read_tls_early_data(SSL *ssl, int *err)
 {
-    size_t buf_siz = PIXEL_TLS_EARLYDATA_SIZE;
+    ssize_t buf_siz = PIXEL_TLS_EARLYDATA_SIZE;
     char *buf, *pbuf;
     int count = 0;
 

--- a/logger.c
+++ b/logger.c
@@ -10,11 +10,10 @@ static logger_level _verb = LGG_ERR;
 static logger_level _verb = LGG_DEBUG;
 #endif
 
-static int ctrl_char(char *buf, int len) {
+static int ctrl_char(char *buf, size_t len) {
     if (strlen(buf) < len)
         return 1;
-    int i;
-    for (i=0; i<(len - 1); i++) {
+    for (size_t i=0; i<(len - 1); i++) {
         if (buf[i] >= 10 && buf[i] <= 13)
             continue;
         if (buf[i] < 32) {
@@ -27,7 +26,7 @@ static int ctrl_char(char *buf, int len) {
 void log_set_verb(logger_level verb) { _verb = verb; }
 logger_level log_get_verb() { return _verb; }
 
-void log_msg(int verb, char *fmt, ...)
+void log_msg(logger_level verb, char *fmt, ...)
 {
     if (verb > _verb)
         return;
@@ -38,7 +37,7 @@ void log_msg(int verb, char *fmt, ...)
     va_end(args);
 }
 
-void log_xcs(int verb, char *client_ip, char *host, int tls, char *req, char *body, int body_len)
+void log_xcs(logger_level verb, char *client_ip, char *host, int tls, char *req, char *body, size_t body_len)
 {
     if (verb > _verb || !client_ip || !host || !req)
       return;

--- a/logger.h
+++ b/logger.h
@@ -14,7 +14,7 @@ typedef enum {
 
 void log_set_verb(logger_level verb);
 logger_level log_get_verb();
-void log_msg(int verb, char *fmt, ...);
-void log_xcs(int verb, char *client_ip, char *host, int tls, char *req, char *body, int body_len);
+void log_msg(logger_level verb, char *fmt, ...);
+void log_xcs(logger_level verb, char *client_ip, char *host, int tls, char *req, char *body, size_t body_len);
 
 #endif

--- a/pixelserv.c
+++ b/pixelserv.c
@@ -196,7 +196,7 @@ int main (int argc, char* argv[])
           continue;
           case 'l':
             if ((logger_level)atoi(argv[i]) > LGG_DEBUG
-                || (logger_level)atoi(argv[i]) < 0)
+                || atoi(argv[i]) < 0)
               error = 1;
             else
               log_set_verb((logger_level)atoi(argv[i]));

--- a/pixelserv.c
+++ b/pixelserv.c
@@ -105,7 +105,7 @@ int main (int argc, char* argv[])
   struct addrinfo hints, *servinfo;
   int error = 0;
   int pipefd[2];  // IPC pipe ends (0 = read, 1 = write)
-  response_struct pipedata = { FAIL_GENERAL, { 0 }, 0.0, 0 };
+  response_struct pipedata = { 0 };
   char* ports[MAX_PORTS + 1]; /* one extra port for admin */
   char *port = NULL;
   fd_set readfds;

--- a/socket_handler.c
+++ b/socket_handler.c
@@ -651,11 +651,11 @@ void* conn_handler( void *ptr )
   char* stat_string = NULL;
   int num_req = 0; // number of requests processed by this thread
   char *req_url = NULL;
-  int req_len = 0;
+  unsigned int req_len = 0;
   #define HOST_LEN_MAX 80
   char host[HOST_LEN_MAX + 1];
   char *post_buf = NULL;
-  int post_buf_len = 0;
+  size_t post_buf_len = 0;
   unsigned int total_bytes = 0; /* number of bytes received by this thread */
   #define CORS_ORIGIN_LEN_MAX 256
   char *cors_origin = NULL;
@@ -938,11 +938,12 @@ end_post:
                NULL != (fp = fopen(ca_file, "r")))
             {
               fseek(fp, 0L, SEEK_END);
-              int file_sz = ftell(fp);
-              rsize = asprintf(&aspbuf, "%s%d%s", httpcacert, file_sz, httpcacert2);
+              long file_sz = ftell(fp);
               rewind(fp);
+              rsize = asprintf(&aspbuf, "%s%ld%s", httpcacert, file_sz, httpcacert2);
               if ((aspbuf = (char*)realloc(aspbuf, rsize + file_sz + 16)) != NULL &&
-                     fread(aspbuf + rsize, 1, file_sz, fp) == file_sz) {
+                     fread(aspbuf + rsize, 1, file_sz, fp) == (size_t)file_sz) {
+                                                              // should be fairly safe to cast here
                 response = aspbuf;
                 rsize += file_sz;
                 pipedata.status = SEND_TXT;

--- a/socket_handler.c
+++ b/socket_handler.c
@@ -1025,8 +1025,8 @@ end_post:
                 rsize = asprintf(&aspbuf, httpredirect, url, "");
               } else {
                 char *tmpcors = NULL;
-                asprintf(&tmpcors, httpcors_headers, cors_origin);
-                rsize = asprintf(&aspbuf, httpredirect, url, tmpcors);
+                int ret = asprintf(&tmpcors, httpcors_headers, cors_origin);
+                if (ret) rsize = asprintf(&aspbuf, httpredirect, url, tmpcors);
                 free(tmpcors);
               }
               pipedata.status = SEND_REDIRECT;
@@ -1106,8 +1106,8 @@ end_post:
           rsize = asprintf(&aspbuf, httpnulltext, "");
         } else {
           char *tmpcors = NULL;
-          asprintf(&tmpcors, httpcors_headers, cors_origin);
-          rsize = asprintf(&aspbuf, httpnulltext, tmpcors);
+          int ret = asprintf(&tmpcors, httpcors_headers, cors_origin);
+          if (ret) rsize = asprintf(&aspbuf, httpnulltext, tmpcors);
           free(tmpcors);
         }
         response = aspbuf;

--- a/util.c
+++ b/util.c
@@ -84,7 +84,7 @@ unsigned int process_uptime()
 char* get_version(int argc, char* argv[]) {
   char* retbuf = NULL;
   char* optbuf = NULL;
-  unsigned int optlen = 0, i = 1, freeoptbuf = 0;
+  unsigned int optlen = 0, freeoptbuf = 0;
   unsigned int arglen[argc];
 
   // capture startup_time if not yet set
@@ -93,7 +93,7 @@ char* get_version(int argc, char* argv[]) {
   }
 
   // determine total size of all arguments
-  for (i = 1; i < argc; ++i) {
+  for (int i = 1; i < argc; ++i) {
     arglen[i] = strlen(argv[i]) + 1; // add 1 for leading space
     optlen += arglen[i];
   }
@@ -103,7 +103,7 @@ char* get_version(int argc, char* argv[]) {
     if (optbuf) {
       freeoptbuf = 1;
       // concatenate arguments into buffer
-      for (i = 1, optlen = 0; i < argc; ++i) {
+      for (int i = 1, optlen = 0; i < argc; ++i) {
         optbuf[optlen] = ' '; // prepend a space to each argument
         strncpy(optbuf + optlen + 1, argv[i], arglen[i]);
         optlen += arglen[i];


### PR DESCRIPTION
Squash some warnings with `-Wall -Werror -Wextra -Wformat -Wformat-security -Wno-error=unused-parameter -Wimplicit-fallthrough` with gcc-9/clang-9