### PR TITLE
README.md instructions append with wget instead of curl -o patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Binary packages are available from this [Github](https://github.com/jumpsmm7/). 
 ````
 sudo -i
 cd /tmp
-curl -O https://github.com/jumpsmm7/pixelserv-tls_2.3.1-1_armhf.deb/raw/master/pixelserv-tls_2.3.1-1_armhf.deb
+wget https://github.com/jumpsmm7/pixelserv-tls_2.3.1-1_armhf.deb/raw/master/pixelserv-tls_2.3.1-1_armhf.deb
 dpkg -i pixelserv-tls_2.3.1-1_armhf.deb
 ````
 and follow the on-screen instructions.


### PR DESCRIPTION
Replace curl -o with wget as users are reporting .deb file will not install. curl -o was found to corrupt file on download.